### PR TITLE
Make code formatting consistent between xgx_scale_x_time_units() and xgx_scale_y_time_units()

### DIFF
--- a/R/xgx_scale_x_time_units.R
+++ b/R/xgx_scale_x_time_units.R
@@ -105,12 +105,15 @@ xgx_scale_x_time_units <- function(units_dataset, units_plot = NULL,
 
 #' @rdname xgx_scale_x_time_units
 #' @export
-xgx_scale_y_time_units <-
-  function(units_dataset, units_plot = NULL, breaks = NULL, labels = NULL,
-           ...) {
-    lst <- xgx_scale_time_units_(units_dataset, units_plot, breaks, labels, ...)
-    return(list(ggplot2::scale_y_continuous(
+xgx_scale_y_time_units <- function(units_dataset, units_plot = NULL,
+                                   breaks = NULL,
+                                   labels = NULL, ...) {
+  lst <- xgx_scale_time_units_(units_dataset, units_plot, breaks, labels, ...)
+  return(list(
+    ggplot2::scale_y_continuous(
       breaks = lst$breaks,
       labels = lst$labels, ...
-    ), ggplot2::ylab(lst$xlabel)))
-  }
+    ),
+    ggplot2::ylab(lst$xlabel)
+  ))
+}


### PR DESCRIPTION
This makes no functional changes.  I was looking to see what differences were happening between the two functions, but it was just the formatting, so I made them consistent.