### PR TITLE
Use user-specified `number_breaks` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xgxr
 Title: Exploratory Graphics for Pharmacometrics
-Version: 1.1.4
+Version: 1.1.5
 Authors@R:
     c(person(given = "Andrew",
              family = "Stein",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+CHANGES IN VERSION 1.1.5
+------------------------
+    o xgx_breaks_time: Fix bug where user-specified `number_breaks` argument was ignored.
+
 CHANGES IN VERSION 1.1.4
 ------------------------
     o xgx_stat_ci: 

--- a/R/xgx_breaks_time.R
+++ b/R/xgx_breaks_time.R
@@ -46,7 +46,6 @@ xgx_breaks_time <-  function(data_range, units_plot, number_breaks = 5) {
   data_min <- min(data_range)
   data_max <- max(data_range)
   data_span <- data_max - data_min
-  number_breaks <- 5 # number of breaks to aim for
   preferred_increment_default <- c(1, 5, 2, 4, 3, 1)
   weights_default <- c(0.25, 0.2, 0.5, 0.05)
   weights_simple <- c(1, 0.2, 0.5, 0.05)

--- a/tests/testthat/test-xgx_breaks_time.R
+++ b/tests/testthat/test-xgx_breaks_time.R
@@ -1,0 +1,8 @@
+test_that("xgx_breaks_time() allows user to set a preferred number of breaks", {
+  expect_identical(xgx_breaks_time(c(0, 100), "hour"), # default 5 breaks
+                   seq(0, 96, by = 24))
+  expect_identical(xgx_breaks_time(c(0, 100), units_plot = "hour", number_breaks = 5),
+                   seq(0, 96, by = 24))
+  expect_identical(xgx_breaks_time(c(0, 100), units_plot = "hour", number_breaks = 10),
+                   seq(0, 96, by = 12))
+})


### PR DESCRIPTION
In this [old commit](https://github.com/Novartis/xgxr/commit/5c8b26bf9e464c48ea376aec2d75b1e0d08e79d4), a new argument is added, but is immediately overwritten at the start of the function, so it has no effect. This removes the overwrite so the user can adjust the number of breaks.